### PR TITLE
Prob_p and onemE

### DIFF
--- a/lib/Reals_ext.v
+++ b/lib/Reals_ext.v
@@ -322,91 +322,87 @@ suff : Hf = Hg by move=> ->.
 exact/boolp.Prop_irrelevance.
 Qed.
 
+Section Rstruct_ext.
+
+Lemma RleP' (x y : R) : Rle x y <-> (x <= y)%O.
+Proof. by split; move/RleP. Qed.
+
+Lemma RltP' (x y : R) : Rlt x y <-> (x < y)%O.
+Proof. by split; move/RltP. Qed.
+
+End Rstruct_ext.
+
 Section onem.
 Implicit Types r s p q : R.
 
-Definition Ronem r := @onem real_realType r.
-(*Local Notation "p '.~'" := (Ronem p).*)
+Lemma onem0 : 0.~ = 1. Proof. by rewrite onem0. Qed.
 
-Lemma onem0 : 0.~ = 1. Proof. by rewrite /Ronem onem0. Qed.
-
-Lemma onem1 : 1.~ = 0. Proof. by rewrite /Ronem onem1. Qed.
+Lemma onem1 : 1.~ = 0. Proof. by rewrite onem1. Qed.
 
 Lemma onem_ge0 r : r <= 1 -> 0 <= r.~.
-Proof. rewrite /Ronem; move/RleP => r1; exact/RleP/onem_ge0. Qed.
+Proof. by rewrite 2!RleP'; exact: onem_ge0. Qed.
 
 Lemma onem_le1 r : 0 <= r -> r.~ <= 1.
-Proof. move/RleP=> ?; rewrite /Ronem. exact/RleP/onem_le1. Qed.
+Proof. by rewrite 2!RleP'; exact: onem_le1. Qed.
 
-Lemma onem_le  r s : r <= s <-> s.~ <= r.~.
-Proof.
-Admitted.
+Lemma onem_le r s : r <= s <-> s.~ <= r.~.
+Proof. by rewrite 2!RleP' onem_le. Qed.
 
-Lemma onem_lt  r s : r < s <-> s.~ < r.~.
-(*Proof. by rewrite /onem; split=> ?; lra. Qed.*)
-Admitted.
+Lemma onemE x : x.~ = 1 - x.  Proof. by []. Qed.
 
-Lemma onemKC r : r + r.~ = 1. (*TODO Proof. rewrite /onem; by field. Qed.*)
-Admitted.
+Lemma onem_lt  r s : r < s <-> s.~ < r.~. Proof. by rewrite !onemE; lra. Qed.
+
+Lemma onemKC r : r + r.~ = 1. Proof. by rewrite !onemE; lra. Qed.
 
 Lemma onemK r : r.~.~ = r.
-(*Proof. by rewrite /onem subRBA addRC addRK. Qed.*)
-Admitted.
+Proof. by rewrite !onemE subRBA addRC addRK. Qed.
 
 Lemma onemD p q : (p + q).~ = p.~ + q.~ - 1.
-(*Proof. rewrite /onem; field. Qed.*)
-Admitted.
+Proof. rewrite !onemE /GRing.add /=; lra. Qed.
 
 Lemma onemM p q : (p * q).~ = p.~ + q.~ - p.~ * q.~.
-(*Proof. rewrite /onem; field. Qed.*)
-Admitted.
+Proof. rewrite !onemE /GRing.mul /=; lra. Qed.
 
 Lemma onem_div p q : q != 0 -> (p / q)%coqR.~ = (q - p)  /q.
 Proof.
-Admitted.
-(*TODO
+Proof.
+rewrite !onemE.
 move=> Hq.
-rewrite /nonem.
 rewrite /Rdiv.
 rewrite mulRDl.
 rewrite mulNR.
 rewrite -/(q / q).
 rewrite divRR//.
-Qed.*)
+Qed.
 
 Lemma onem_prob r : R0 <b= r <b= R1 -> R0 <b= r.~ <b= R1.
 Proof.
-(*by case/leR2P=> ? ?; apply/leR2P; split;
-   [rewrite leR_subr_addr add0R | rewrite leR_subl_addr -(addR0 1) leR_add2l].
-Qed.*)
-Admitted.
+Proof.
+by case/leR2P=> ? ?; apply/leR2P; split;
+   [ rewrite onemE leR_subr_addr add0R
+   | rewrite onemE leR_subl_addr -(addR0 1) leR_add2l].
+Qed.
 
 Lemma onem_oprob r : R0 <b r <b R1 -> R0 <b r.~ <b R1.
-(*Proof.
+Proof.
 by case/ltR2P=> ? ?; apply/ltR2P; split;
-   [rewrite ltR_subr_addr add0R | rewrite ltR_subl_addr -(addR0 1) ltR_add2l].
-Qed.*)
-Admitted.
+   [ rewrite onemE ltR_subr_addr add0R
+   | rewrite onemE ltR_subl_addr -(addR0 1) ltR_add2l].
+Qed.
 
-Lemma onem_eq0 r : r.~ = 0 <-> r = 1. (*Proof. rewrite /onem; lra. Qed.*)
-Admitted.
+Lemma onem_eq0 r : r.~ = 0 <-> r = 1. Proof. rewrite onemE; lra. Qed.
 
-Lemma onem_eq1 r : r.~ = 1 <-> r = 0. (*Proof. rewrite /onem; lra. Qed.*)
-Admitted.
+Lemma onem_eq1 r : r.~ = 1 <-> r = 0. Proof. rewrite onemE; lra. Qed.
 
 Lemma onem_neq0 r : r.~ != 0 <-> r != 1.
-(*Proof. by split; apply: contra => /eqP/onem_eq0/eqP. Qed.*)
-Admitted.
+Proof. by split; apply: contra => /eqP/onem_eq0/eqP. Qed.
 
-Lemma onem_gt0 r : r < 1 -> 0 < r.~. (*Proof. rewrite /onem; lra. Qed.*)
-Admitted.
+Lemma onem_gt0 r : r < 1 -> 0 < r.~. Proof. rewrite onemE; lra. Qed.
 
-Lemma onem_lt1 r : 0 < r -> r.~ < 1. (*Proof. rewrite /onem; lra. Qed.*)
-Admitted.
+Lemma onem_lt1 r : 0 < r -> r.~ < 1. Proof. rewrite onemE; lra. Qed.
 
 Lemma subR_onem r s : r - s.~ = r + s - 1.
-(*Proof. by rewrite /onem -addR_opp oppRB addRA. Qed.*)
-Admitted.
+Proof. by rewrite onemE -addR_opp oppRB addRA. Qed.
 
 End onem.
 (*Definition Ronem (p: R) := (@onem real_realType p).*)
@@ -445,8 +441,34 @@ Global Hint Resolve prob_le1 : core.*)
 
 (*Reserved Notation "{ 'prob' T }" (at level 0, format "{ 'prob'  T }").
 Definition prob_of (R : realType) := fun phT : phant (Num.NumDomain.sort (*Real.sort*)R) => @prob R.*)
+
+Section ad_hoc_coercion_from_prob_to_R.
+(*Section test.
+Variable p : {prob R}.
+Check p.
+Fail Check p : R.
+Check Prob.p p.
+Check p : reals.Real.sort real_realType.
+Check erefl : reals.Real.sort real_realType = R.
+Fail Check p : R.
+Check p : reals.Real.sort real_realType.
+Check Prob.p.
+End test.*)
+Definition Prob_p : Prob.t (real_realType) -> R.
+exact: Prob.p.
+Defined.
+Lemma Prob_pE p : Prob_p p = @Prob.p real_realType p.
+Proof. by []. Qed.
+(*Section test2.
+Local Coercion Prob_p : prob >-> R.
+Variable p : {prob R}.
+Check p : R.
+End test2.*)
+End ad_hoc_coercion_from_prob_to_R.
+Coercion Prob_p : prob >-> R.
+
 Notation "{ 'prob' T }" := (@prob_of _ (Phant T)).
-Definition probR_coercion (p : {prob R}) : R := Prob.p p.
+Definition probR_coercion (p : {prob R}) : R := Prob_p p.
 Local Coercion probR_coercion : prob_of >-> R.
 
 Lemma probR_ge0 (p : {prob R}) : 0 <= p. Proof. exact/RleP/prob_ge0. Qed.

--- a/lib/Reals_ext.v
+++ b/lib/Reals_ext.v
@@ -445,7 +445,7 @@ Definition prob_of (R : realType) := fun phT : phant (Num.NumDomain.sort (*Real.
 Section ad_hoc_coercion_from_prob_to_R.
 (*
 Prob_p compensates a missing coercion from real_realType to R.
-without Prob_p, the p : {prob R} fails to type check as p : R as follows: 
+Without Prob_p, (p : {prob R}) fails to typecheck as (p : R) as follows:
 
 Variable p : {prob R}.
 Check p.

--- a/lib/Reals_ext.v
+++ b/lib/Reals_ext.v
@@ -443,32 +443,33 @@ Global Hint Resolve prob_le1 : core.*)
 Definition prob_of (R : realType) := fun phT : phant (Num.NumDomain.sort (*Real.sort*)R) => @prob R.*)
 
 Section ad_hoc_coercion_from_prob_to_R.
-(*Section test.
+(*
+Prob_p compensates a missing coercion from real_realType to R.
+without Prob_p, the p : {prob R} fails to type check as p : R as follows: 
+
 Variable p : {prob R}.
 Check p.
 Fail Check p : R.
 Check Prob.p p.
-Check p : reals.Real.sort real_realType.
-Check erefl : reals.Real.sort real_realType = R.
-Fail Check p : R.
-Check p : reals.Real.sort real_realType.
-Check Prob.p.
-End test.*)
+
+This problem may be solved by using HB in the definition of realType in mca,
+and then Prob_p should be removed.
+
+Prob_p in a goal blocks uses of some lemmas and must be removed manually by
+`rewrite Prob_pE`.
+The notation `%:pp` is for indicating where a user should do this.
+*)
 Definition Prob_p : Prob.t (real_realType) -> R.
 exact: Prob.p.
 Defined.
 Lemma Prob_pE p : Prob_p p = @Prob.p real_realType p.
 Proof. by []. Qed.
-(*Section test2.
-Local Coercion Prob_p : prob >-> R.
-Variable p : {prob R}.
-Check p : R.
-End test2.*)
 End ad_hoc_coercion_from_prob_to_R.
 Coercion Prob_p : prob >-> R.
+Notation "p %:pp" := (Prob_p p) (at level 1, format "p %:pp").
 
 Notation "{ 'prob' T }" := (@prob_of _ (Phant T)).
-Definition probR_coercion (p : {prob R}) : R := Prob_p p.
+Definition probR_coercion (p : {prob R}) : R := Prob.p p.
 Local Coercion probR_coercion : prob_of >-> R.
 
 Lemma probR_ge0 (p : {prob R}) : 0 <= p. Proof. exact/RleP/prob_ge0. Qed.

--- a/probability/fsdist.v
+++ b/probability/fsdist.v
@@ -710,20 +710,18 @@ Variables (A : choiceType) (p : {prob R}) (d1 d2 : {dist A}).
 
 Definition fsdist_conv : {dist A} := locked
   (fsdist_convn (fdistI2 p) (fun i => if i == ord0 then d1 else d2)).
-Local Open Scope reals_ext_scope.
 
-Lemma fsdist_convE a : (fsdist_conv a = Prob.p p * d1 a + p.~ * d2 a)%coqR.
+Lemma fsdist_convE a : (fsdist_conv a = p * d1 a + p.~ * d2 a)%coqR.
 Proof.
 rewrite /fsdist_conv; unlock => /=; rewrite fsdist_convnE fsfunE.
 case: ifPn => [?|H].
   rewrite !big_ord_recl big_ord0 /= addR0 !fdistI2E.
   by rewrite eqxx eq_sym (negbTE (neq_lift _ _)).
-have [p0|p0] := eqVneq (Prob.p p : R) 0%coqR.
+have [p0|p0] := eqVneq p 0%:pr.
   rewrite p0 mul0R add0R onem0 mul1R.
   apply/esym/eqP; rewrite -memNfinsupp.
   apply: contra H => H.
-  rewrite (_ : p = R0%:pr) //; last exact/val_inj.
-  rewrite fdistI20 (_ : Ordinal _ = @ord_max 1); last exact/val_inj.
+  rewrite p0 fdistI20 (_ : Ordinal _ = @ord_max 1); last exact/val_inj.
   (* TODO: generalize *)
   suff : fsdist_convn_supp (fdist1 ord_max)
     (fun i : 'I_2 => if i == ord0 then d1 else d2) = finsupp d2 by move=> ->.
@@ -738,7 +736,7 @@ have d1a0 : d1 a = 0.
   rewrite /fsdist_convn_supp; apply/bigfcupP; exists ord0; last by rewrite eqxx.
   by rewrite mem_index_enum /= fdistI2E eqxx; exact/ltRP/probR_gt0.
 rewrite d1a0 mulR0 add0R.
-have [p1|p1] := eqVneq (Prob.p p : R) 1%coqR; first by rewrite p1 onem1 mul0R.
+have [p1|p1] := eqVneq p 1%:pr; first by rewrite p1 onem1 mul0R.
 suff : d2 a = 0 by move=> ->; rewrite mulR0.
 apply/eqP; rewrite -memNfinsupp.
 apply: contra H => H.
@@ -763,12 +761,8 @@ Proof.
 move=> p0; apply/fsubsetP => a1.
 rewrite !mem_finsupp => aa1.
 rewrite fsdist_convE.
-apply: contra aa1 => /eqP.
-rewrite paddR_eq0; [move=> [+ _]|exact/mulR_ge0|exact/mulR_ge0].
-rewrite mulR_eq0 => -[p0'|/eqP //].
-exfalso.
-move/eqP : p0; apply.
-by apply/val_inj; rewrite /= p0'.
+apply/paddR_neq0; [exact/mulR_ge0|exact/mulR_ge0|left].
+by rewrite mulR_neq0' aa1 andbT.
 Qed.
 
 Lemma fsdistbindEwiden (B : choiceType) (a b : {dist A}) (f : A -> {dist B})
@@ -810,18 +804,18 @@ by apply/fsdist_ext => a; rewrite 2!fsdist_convE /= onemK addRC.
 Qed.
 
 Definition fsdist_convA (p q r s : {prob R}) (mx my mz : {dist A}) :
-  Prob.p p = Prob.p r * Prob.p s :> R /\ s.~ = p.~ * q.~ ->
+  p = r * s :> R /\ s.~ = p.~ * q.~ ->
   mx <| p |> (my <| q |> mz) = (mx <| r |> my) <| s |> mz.
 Proof.
-move=> [Hp Hs]; apply/fsdist_ext => a.
-rewrite !fsdist_convE [in RHS]mulRDr (@mulRCA _ (Prob.p r)) (@mulRA (Prob.p r)) -Hp -addRA; congr (_ + _)%coqR.
+rewrite !Prob_pE; move=> [Hp Hs]; apply/fsdist_ext => a.
+rewrite !fsdist_convE [in RHS]mulRDr (@mulRCA _ r) (@mulRA r) -Hp -addRA; congr (_ + _)%coqR.
 rewrite mulRDr (@mulRA p.~ q.~) -Hs; congr (_ + _)%coqR.
 rewrite !mulRA; congr (_ * _)%coqR.
 rewrite -p_of_rsE in Hp.
 move/(congr1 (@onem _)) : Hs; rewrite onemK => Hs.
 rewrite -s_of_pqE in Hs.
 have [r0|r0] := eqVneq r R0%:pr.
-  rewrite r0 /= onem0 mulR1 Hs s_of_pqE.
+  rewrite r0 onem0 mulR1 !Prob_pE Hs s_of_pqE.
   by rewrite Hp p_of_rsE r0 /= mul0R onem0 2!mul1R onemK.
 have [s0|s0] := eqVneq s R0%:pr.
   rewrite Hp p_of_rsE s0 /= mulR0 onem0 mul0R mul1R.
@@ -839,7 +833,7 @@ Let convA (p q : {prob R}) (a b c : {dist A}) :
   a <| p |> (b <| q |> c) = (a <| r_of_pq p q |> b) <| s_of_pq p q |> c.
 Proof.
 rewrite (fsdist_convA (r := r_of_pq p q) (s := s_of_pq p q)) //.
-rewrite {2}s_of_pqE onemK; split => //.
+rewrite !Prob_pE {2}s_of_pqE onemK; split => //.
 have [s0|s0] := eqVneq (s_of_pq p q) R0%:pr.
 - rewrite s0 mulR0; apply/eqP; move/eqP: s0.
   by apply: contraTT => /(s_of_gt0 q); rewrite probR_gt0.


### PR DESCRIPTION
Prob_p : prob >-> Rというcoercionを追加して
```
Variable p : {prob R}.
Check p : R.
```
が通るようにし、証明中でこれが邪魔になったとき
消すためのProb_pEという補題を追加しています。

また、Reals_extでのRに特化したonemについてonemEという補題を追加し、
いくつかadmitをつぶしています。
